### PR TITLE
Change WhoisRecord route param from :id to :name

### DIFF
--- a/app/controllers/whois_records_controller.rb
+++ b/app/controllers/whois_records_controller.rb
@@ -2,7 +2,7 @@ class WhoisRecordsController < ApplicationController
   helper_method :ip_in_whitelist?
 
   def show
-    domain_name = SimpleIDN.to_unicode(params[:id].to_s).downcase
+    domain_name = SimpleIDN.to_unicode(params[:name].to_s).downcase
     @whois_record = WhoisRecord.find_by(name: domain_name)
 
     @show_sensitive_data = (ip_in_whitelist? || captcha_solved?)
@@ -34,13 +34,13 @@ class WhoisRecordsController < ApplicationController
   def log_message(params, whois_record)
     if whois_record
       Rails.logger.warn(
-        "Requested: #{params[:id]}; " \
+        "Requested: #{params[:name]}; " \
         "Record found with id: #{@whois_record.id}; " \
         "Captcha result: #{captcha_solved? ? 'yes' : 'no'}; ip: #{request.remote_ip};"
       )
     else
       Rails.logger.warn(
-        "Requested: #{params[:id]}; Record not found; " \
+        "Requested: #{params[:name]}; Record not found; " \
         "Captcha result: #{captcha_solved? ? 'yes' : 'no'}; ip: #{request.remote_ip};"
       )
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   resources :contact_requests, only: [:new, :create, :update, :show, :edit], param: :secret
 
   scope '/v1' do
-    get '*id', to: 'whois_records#show', constraints: { id: /([^\/]+?)(?=\.json|\.html|$|\/)/ }
-    post '*id', to: 'whois_records#show', constraints: { id: /([^\/]+?)(?=\.json|\.html|$|\/)/ }
+    get ':name', to: 'whois_records#show', constraints: { name: /([^\/]+?)(?=\.json|\.html|$|\/)/ }
+    post ':name', to: 'whois_records#show', constraints: { name: /([^\/]+?)(?=\.json|\.html|$|\/)/ }
   end
 end


### PR DESCRIPTION
The name of URL parameter in whois controller is confusing and just wrong, so changing it to correspond to the actual field in `whois_records` table.