### PR TITLE
Set contact form default locale to ET

### DIFF
--- a/app/controllers/whois_records_controller.rb
+++ b/app/controllers/whois_records_controller.rb
@@ -1,5 +1,6 @@
 class WhoisRecordsController < ApplicationController
   helper_method :ip_in_whitelist?
+  helper_method :contact_form_default_locale
 
   def show
     domain_name = SimpleIDN.to_unicode(params[:name].to_s).downcase
@@ -54,5 +55,9 @@ class WhoisRecordsController < ApplicationController
 
   def captcha_solved?
     verify_recaptcha
+  end
+
+  def contact_form_default_locale
+    :et
   end
 end

--- a/app/views/whois_records/_private_person.json.jbuilder
+++ b/app/views/whois_records/_private_person.json.jbuilder
@@ -38,4 +38,5 @@ json.admin_contacts do
   end
 end
 
-json.contact_form_link new_contact_request_url({ domain_name: whois_record.name })
+json.contact_form_link new_contact_request_url({ domain_name: whois_record.name,
+                                                 locale: contact_form_default_locale })

--- a/test/integration/whois_records/json_test.rb
+++ b/test/integration/whois_records/json_test.rb
@@ -72,7 +72,7 @@ class WhoisRecordJsonTest < ActionDispatch::IntegrationTest
       'tech_contacts': [{'changed': 'Not Disclosed',
                          'email': 'Not Disclosed',
                          'name': 'Not Disclosed'}],
-      'contact_form_link': 'http://www.example.com/contact_requests/new?domain_name=privatedomain.test&locale=en'
+      'contact_form_link': 'http://www.example.com/contact_requests/new?domain_name=privatedomain.test&locale=et'
     }.with_indifferent_access
 
     get('/v1/privatedomain.test.json')


### PR DESCRIPTION
Closes #74 

Hard-coded ET value, since it is very unlikely we even need to change it.