### PR TITLE
Add ability to use different database for ContactRequests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Examlpe usege:
 By default there will return only public info.
 If you need full whois info, user needs to use Google ReCaptchia, example usage:
 
-1) html for full whois info, GET: 
-    
+1) html for full whois info, GET:
+
     /v1/test.ee?utf8=%E2%9C%93&g-recaptcha-response=03AHJ_VuvVgYnzxXAuf8rdHvTPQ5FZSHYZ...
 
 2) json for full whois info, GET:
@@ -37,12 +37,11 @@ Manual demo install:
 
     git clone https://github.com/internetee/rest-whois/
     cd rest-whois
-    rbenv local 2.2.6
+    rbenv local 2.3.7
     bundle install
     cp config/application-example.yml config/application.yml # and edit it
     cp config/database-example.yml config/database.yml # and edit it
     bundle exec rake db:setup # for production, please follow deployment howto
-
 
 Deployment
 ----------
@@ -88,4 +87,3 @@ Add apache config file:
 Deploy from your machine:
 
     mina pr deploy
-

--- a/app/models/contact_request.rb
+++ b/app/models/contact_request.rb
@@ -1,8 +1,7 @@
 class ContactRequest < ActiveRecord::Base
   def self.connect_to_write_database_if_defined
-    if Rails.configuration.database_configuration["write_#{Rails.env}"]
-      establish_connection "write_#{Rails.env}".to_sym
-    end
+    return unless Rails.configuration.database_configuration["write_#{Rails.env}"]
+    establish_connection "write_#{Rails.env}".to_sym
   end
 
   connect_to_write_database_if_defined

--- a/app/models/contact_request.rb
+++ b/app/models/contact_request.rb
@@ -1,7 +1,11 @@
 class ContactRequest < ActiveRecord::Base
-  if Rails.env.production?
-    establish_connection "write_#{Rails.env}".to_sym
+  def self.connect_to_write_database_if_defined
+    if Rails.configuration.database_configuration["write_#{Rails.env}"]
+      establish_connection "write_#{Rails.env}".to_sym
+    end
   end
+
+  connect_to_write_database_if_defined
 
   STATUS_NEW       = 'new'.freeze
   STATUS_CONFIRMED = 'confirmed'.freeze

--- a/app/models/contact_request.rb
+++ b/app/models/contact_request.rb
@@ -1,4 +1,6 @@
 class ContactRequest < ActiveRecord::Base
+  establish_connection :production_write if Rails.env.production?
+
   STATUS_NEW       = 'new'.freeze
   STATUS_CONFIRMED = 'confirmed'.freeze
   STATUS_SENT      = 'sent'.freeze

--- a/app/models/contact_request.rb
+++ b/app/models/contact_request.rb
@@ -1,5 +1,7 @@
 class ContactRequest < ActiveRecord::Base
-  establish_connection :production_write if Rails.env.production?
+  if Rails.env.production?
+    establish_connection "write_#{Rails.env}".to_sym
+  end
 
   STATUS_NEW       = 'new'.freeze
   STATUS_CONFIRMED = 'confirmed'.freeze

--- a/app/models/whois_record.rb
+++ b/app/models/whois_record.rb
@@ -1,4 +1,6 @@
 class WhoisRecord < ActiveRecord::Base
+  establish_connection :production_read_only if Rails.env.production?
+
   BLOCKED = 'Blocked'.freeze
   RESERVED = 'Reserved'.freeze
   DISCARDED = 'deleteCandidate'.freeze

--- a/app/models/whois_record.rb
+++ b/app/models/whois_record.rb
@@ -1,8 +1,4 @@
 class WhoisRecord < ActiveRecord::Base
-  if Rails.env.production?
-    establish_connection "read_#{Rails.env}".to_sym
-  end
-
   BLOCKED = 'Blocked'.freeze
   RESERVED = 'Reserved'.freeze
   DISCARDED = 'deleteCandidate'.freeze

--- a/app/models/whois_record.rb
+++ b/app/models/whois_record.rb
@@ -1,5 +1,7 @@
 class WhoisRecord < ActiveRecord::Base
-  establish_connection :production_read_only if Rails.env.production?
+  if Rails.env.production?
+    establish_connection "read_#{Rails.env}".to_sym
+  end
 
   BLOCKED = 'Blocked'.freeze
   RESERVED = 'Reserved'.freeze

--- a/config/database-example.yml
+++ b/config/database-example.yml
@@ -14,12 +14,13 @@ test:
   <<: *default
   database: rest_whois_test
 
-# Our production environment use two separate databases for different models.
-# WhoisRecord are read-only, while ContactRequests need write access to
-read_production:
+production:
   <<: *default
   database: rest_whois_production
 
-write_production:
-  <<: *default
-  database: rest_whois_production
+# Our production environment use two separate databases for different models. WhoisRecord are
+# read-only, while ContactRequests need write access. To enable access to second database,
+# ucommment the following lines
+# write_production:
+#   <<: *default
+#   database: rest_whois_production

--- a/config/database-example.yml
+++ b/config/database-example.yml
@@ -14,6 +14,12 @@ test:
   <<: *default
   database: rest_whois_test
 
-production:
+# Our production environment use two separate databases for different models.
+# WhoisRecord are read-only, while ContactRequests need write access to
+production_read_only:
+  <<: *default
+  database: rest_whois_production
+
+production_write:
   <<: *default
   database: rest_whois_production

--- a/config/database-example.yml
+++ b/config/database-example.yml
@@ -16,10 +16,10 @@ test:
 
 # Our production environment use two separate databases for different models.
 # WhoisRecord are read-only, while ContactRequests need write access to
-production_read_only:
+read_production:
   <<: *default
   database: rest_whois_production
 
-production_write:
+write_production:
   <<: *default
   database: rest_whois_production

--- a/config/database-example.yml
+++ b/config/database-example.yml
@@ -20,7 +20,8 @@ production:
 
 # Our production environment use two separate databases for different models. WhoisRecord are
 # read-only, while ContactRequests need write access. To enable access to second database,
-# ucommment the following lines
+# ucommment the following lines.
+# You can also define write_development, or write_test databases, depending on your needs
 # write_production:
 #   <<: *default
 #   database: rest_whois_production

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,10 +1,10 @@
 namespace :db do
   namespace :production do
-    desc "Migrate both databases in production"
-    task :migrate => :environment do
+    desc 'Migrate both databases in production'
+    task migrate: :environment do
       if Rails.env.production?
 
-        [:write_production, :production].each do |connection|
+        %i[write_production production].each do |connection|
           ActiveRecord::Base.clear_all_connections!
           ActiveRecord::Base.establish_connection(connection)
           Rake::Task['db:migrate'].invoke

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,15 @@
+namespace :db do
+  namespace :production do
+    desc "Migrate both databases in production"
+    task :migrate => :environment do
+      if Rails.env.production?
+
+        [:write_production, :read_production].each do |connection|
+          ActiveRecord::Base.clear_all_connections!
+          ActiveRecord::Base.establish_connection(connection)
+          Rake::Task['db:migrate'].invoke
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -4,7 +4,7 @@ namespace :db do
     task :migrate => :environment do
       if Rails.env.production?
 
-        [:write_production, :read_production].each do |connection|
+        [:write_production, :production].each do |connection|
           ActiveRecord::Base.clear_all_connections!
           ActiveRecord::Base.establish_connection(connection)
           Rake::Task['db:migrate'].invoke


### PR DESCRIPTION
Fixes #93 

Introduces second database definition, `write_$environment_name` (`write_production`) that can be used with the purpose as @teadur described in the original ticket.

Can be tested on staging by defining a `write_staging` database in `config/application.yml`, it would work similarly.