### PR TITLE
Fix typo

### DIFF
--- a/app/views/whois_records/_legal_person.html.erb
+++ b/app/views/whois_records/_legal_person.html.erb
@@ -13,24 +13,24 @@ Registrant:
 name:       <%= json['registrant'] %>
 org id:     <%= json['registrant_reg_no'] %>
 country:    <%= json['registrant_ident_country_code'] %>
-email:      Not Disclosed - Visit www.internet.ee for webbased WHOIS
-changed:    Not Disclosed - Visit www.internet.ee for webbased WHOIS
+email:      Not Disclosed - Visit www.internet.ee for web-based WHOIS
+changed:    Not Disclosed - Visit www.internet.ee for web-based WHOIS
 
 <%- if json['admin_contacts'].present? -%>
 Administrative contact:
 <%- for contact in json['admin_contacts'] -%>
-name:       Not Disclosed - Visit www.internet.ee for webbased WHOIS
-email:      Not Disclosed - Visit www.internet.ee for webbased WHOIS
-changed:    Not Disclosed - Visit www.internet.ee for webbased WHOIS
+name:       Not Disclosed - Visit www.internet.ee for web-based WHOIS
+email:      Not Disclosed - Visit www.internet.ee for web-based WHOIS
+changed:    Not Disclosed - Visit www.internet.ee for web-based WHOIS
 <%- end -%>
 <%- end -%>
 
 <%- if json['tech_contacts'].present? -%>
 Technical contact:
 <%- for contact in json['tech_contacts'] -%>
-name:       Not Disclosed - Visit www.internet.ee for webbased WHOIS
-email:      Not Disclosed - Visit www.internet.ee for webbased WHOIS
-changed:    Not Disclosed - Visit www.internet.ee for webbased WHOIS
+name:       Not Disclosed - Visit www.internet.ee for web-based WHOIS
+email:      Not Disclosed - Visit www.internet.ee for web-based WHOIS
+changed:    Not Disclosed - Visit www.internet.ee for web-based WHOIS
 <%- end -%>
 <%- end -%>
 

--- a/app/views/whois_records/_legal_person.json.jbuilder
+++ b/app/views/whois_records/_legal_person.json.jbuilder
@@ -10,7 +10,7 @@ json.nameservers_changed whois_record.json['nameservers_changed']
 json.outzone whois_record.json['outzone']
 json.registered whois_record.json['registered']
 
-json.registrant_changed 'Not Disclosed - Visit www.internet.ee for webbased WHOIS'
+json.registrant_changed 'Not Disclosed - Visit www.internet.ee for web-based WHOIS'
 json.registrant_kind whois_record.json['registrant_kind']
 
 json.registrar whois_record.json['registrar']
@@ -19,22 +19,22 @@ json.registrar_changed whois_record.json['registrar_changed']
 json.registrar_phone whois_record.json['registrar_phone']
 json.registrar_website whois_record.json['registrar_website']
 
-json.email 'Not Disclosed - Visit www.internet.ee for webbased WHOIS'
+json.email 'Not Disclosed - Visit www.internet.ee for web-based WHOIS'
 json.registrant whois_record.json['registrant']
 json.registrant_reg_no whois_record.json['registrant_reg_no']
 json.registrant_ident_country_code whois_record.json['registrant_ident_country_code']
 
 json.tech_contacts do
   json.array!(whois_record.json['tech_contacts']) do |_contact|
-    json.name 'Not Disclosed - Visit www.internet.ee for webbased WHOIS'
-    json.email 'Not Disclosed - Visit www.internet.ee for webbased WHOIS'
-    json.changed 'Not Disclosed - Visit www.internet.ee for webbased WHOIS'
+    json.name 'Not Disclosed - Visit www.internet.ee for web-based WHOIS'
+    json.email 'Not Disclosed - Visit www.internet.ee for web-based WHOIS'
+    json.changed 'Not Disclosed - Visit www.internet.ee for web-based WHOIS'
   end
 end
 json.admin_contacts do
   json.array!(whois_record.json['admin_contacts']) do |_contact|
-    json.name 'Not Disclosed - Visit www.internet.ee for webbased WHOIS'
-    json.email 'Not Disclosed - Visit www.internet.ee for webbased WHOIS'
-    json.changed 'Not Disclosed - Visit www.internet.ee for webbased WHOIS'
+    json.name 'Not Disclosed - Visit www.internet.ee for web-based WHOIS'
+    json.email 'Not Disclosed - Visit www.internet.ee for web-based WHOIS'
+    json.changed 'Not Disclosed - Visit www.internet.ee for web-based WHOIS'
   end
 end

--- a/test/integration/whois_records/html_test.rb
+++ b/test/integration/whois_records/html_test.rb
@@ -162,18 +162,18 @@ class PrivatePersonWhoisRecordHTMLTest < ActionDispatch::IntegrationTest
         name:    test
         org id:  123
         country: EE
-        email:   Not Disclosed - Visit www.internet.ee for webbased WHOIS
-        changed: Not Disclosed - Visit www.internet.ee for webbased WHOIS
+        email:   Not Disclosed - Visit www.internet.ee for web-based WHOIS
+        changed: Not Disclosed - Visit www.internet.ee for web-based WHOIS
 
         Administrative contact:
-        name:       Not Disclosed - Visit www.internet.ee for webbased WHOIS
-        email:      Not Disclosed - Visit www.internet.ee for webbased WHOIS
-        changed:    Not Disclosed - Visit www.internet.ee for webbased WHOIS
+        name:       Not Disclosed - Visit www.internet.ee for web-based WHOIS
+        email:      Not Disclosed - Visit www.internet.ee for web-based WHOIS
+        changed:    Not Disclosed - Visit www.internet.ee for web-based WHOIS
 
         Technical contact:
-        name:       Not Disclosed - Visit www.internet.ee for webbased WHOIS
-        email:      Not Disclosed - Visit www.internet.ee for webbased WHOIS
-        changed:    Not Disclosed - Visit www.internet.ee for webbased WHOIS
+        name:       Not Disclosed - Visit www.internet.ee for web-based WHOIS
+        email:      Not Disclosed - Visit www.internet.ee for web-based WHOIS
+        changed:    Not Disclosed - Visit www.internet.ee for web-based WHOIS
     TEXT
     )
     assert_button 'Show full WHOIS info'
@@ -270,18 +270,18 @@ class PrivatePersonWhoisRecordHTMLTest < ActionDispatch::IntegrationTest
         name:    test
         org id:  123
         country: EE
-        email:   Not Disclosed - Visit www.internet.ee for webbased WHOIS
-        changed: Not Disclosed - Visit www.internet.ee for webbased WHOIS
+        email:   Not Disclosed - Visit www.internet.ee for web-based WHOIS
+        changed: Not Disclosed - Visit www.internet.ee for web-based WHOIS
 
         Administrative contact:
-        name:       Not Disclosed - Visit www.internet.ee for webbased WHOIS
-        email:      Not Disclosed - Visit www.internet.ee for webbased WHOIS
-        changed:    Not Disclosed - Visit www.internet.ee for webbased WHOIS
+        name:       Not Disclosed - Visit www.internet.ee for web-based WHOIS
+        email:      Not Disclosed - Visit www.internet.ee for web-based WHOIS
+        changed:    Not Disclosed - Visit www.internet.ee for web-based WHOIS
 
         Technical contact:
-        name:       Not Disclosed - Visit www.internet.ee for webbased WHOIS
-        email:      Not Disclosed - Visit www.internet.ee for webbased WHOIS
-        changed:    Not Disclosed - Visit www.internet.ee for webbased WHOIS
+        name:       Not Disclosed - Visit www.internet.ee for web-based WHOIS
+        email:      Not Disclosed - Visit www.internet.ee for web-based WHOIS
+        changed:    Not Disclosed - Visit www.internet.ee for web-based WHOIS
     TEXT
     )
     assert_button 'Show full WHOIS info'

--- a/test/integration/whois_records/json_test.rb
+++ b/test/integration/whois_records/json_test.rb
@@ -112,19 +112,19 @@ class WhoisRecordJsonTest < ActionDispatch::IntegrationTest
     get '/v1/company-domain.test', params: { format: :json }
     response_json = JSON.parse(response.body, symbolize_names: true)
 
-    assert_equal 'Not Disclosed - Visit www.internet.ee for webbased WHOIS', response_json[:email]
-    assert_equal 'Not Disclosed - Visit www.internet.ee for webbased WHOIS',
+    assert_equal 'Not Disclosed - Visit www.internet.ee for web-based WHOIS', response_json[:email]
+    assert_equal 'Not Disclosed - Visit www.internet.ee for web-based WHOIS',
                  response_json[:registrant_changed]
 
     expected_admin_contacts = [
-      { name: 'Not Disclosed - Visit www.internet.ee for webbased WHOIS',
-        email: 'Not Disclosed - Visit www.internet.ee for webbased WHOIS',
-        changed: 'Not Disclosed - Visit www.internet.ee for webbased WHOIS' }
+      { name: 'Not Disclosed - Visit www.internet.ee for web-based WHOIS',
+        email: 'Not Disclosed - Visit www.internet.ee for web-based WHOIS',
+        changed: 'Not Disclosed - Visit www.internet.ee for web-based WHOIS' }
     ]
     expected_tech_contacts = [
-      { name: 'Not Disclosed - Visit www.internet.ee for webbased WHOIS',
-        email: 'Not Disclosed - Visit www.internet.ee for webbased WHOIS',
-        changed: 'Not Disclosed - Visit www.internet.ee for webbased WHOIS' }
+      { name: 'Not Disclosed - Visit www.internet.ee for web-based WHOIS',
+        email: 'Not Disclosed - Visit www.internet.ee for web-based WHOIS',
+        changed: 'Not Disclosed - Visit www.internet.ee for web-based WHOIS' }
     ]
 
     assert_equal expected_admin_contacts, response_json[:admin_contacts]
@@ -210,19 +210,19 @@ class WhoisRecordJsonTest < ActionDispatch::IntegrationTest
     get '/v1/company-domain.test', params: { format: :json }
     response_json = JSON.parse(response.body, symbolize_names: true)
 
-    assert_equal 'Not Disclosed - Visit www.internet.ee for webbased WHOIS', response_json[:email]
-    assert_equal 'Not Disclosed - Visit www.internet.ee for webbased WHOIS',
+    assert_equal 'Not Disclosed - Visit www.internet.ee for web-based WHOIS', response_json[:email]
+    assert_equal 'Not Disclosed - Visit www.internet.ee for web-based WHOIS',
                  response_json[:registrant_changed]
 
     expected_admin_contacts = [
-      { name: 'Not Disclosed - Visit www.internet.ee for webbased WHOIS',
-        email: 'Not Disclosed - Visit www.internet.ee for webbased WHOIS',
-        changed: 'Not Disclosed - Visit www.internet.ee for webbased WHOIS' }
+      { name: 'Not Disclosed - Visit www.internet.ee for web-based WHOIS',
+        email: 'Not Disclosed - Visit www.internet.ee for web-based WHOIS',
+        changed: 'Not Disclosed - Visit www.internet.ee for web-based WHOIS' }
     ]
     expected_tech_contacts = [
-      { name: 'Not Disclosed - Visit www.internet.ee for webbased WHOIS',
-        email: 'Not Disclosed - Visit www.internet.ee for webbased WHOIS',
-        changed: 'Not Disclosed - Visit www.internet.ee for webbased WHOIS' }
+      { name: 'Not Disclosed - Visit www.internet.ee for web-based WHOIS',
+        email: 'Not Disclosed - Visit www.internet.ee for web-based WHOIS',
+        changed: 'Not Disclosed - Visit www.internet.ee for web-based WHOIS' }
     ]
 
     assert_equal expected_admin_contacts, response_json[:admin_contacts]


### PR DESCRIPTION
Related question:

@vohmar Why some "masks" have `Not Disclosed - Visit www.internet.ee for web-based WHOIS` and some just `Not disclosed` text? What is the difference?

P.S. I hope no external system relies on the old `Not Disclosed - Visit www.internet.ee for **webbased** (no dash) WHOIS` string?