### PR TITLE
Remove `SyslogLogger` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'pg', '~> 1.0.0'
 gem 'rails', '~> 5.2.1'
 gem 'recaptcha', require: 'recaptcha/rails'
 gem 'simpleidn', '0.0.7' # For Punycode
-gem 'SyslogLogger', '2.0', require: 'syslog/logger'
 gem 'uglifier'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    SyslogLogger (2.0)
     actioncable (5.2.1.1)
       actionpack (= 5.2.1.1)
       nio4r (~> 2.0)
@@ -180,7 +179,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  SyslogLogger (= 2.0)
   bootsnap
   capybara
   figaro (~> 1.1.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Use a different logger for distributed setups.
-  # require 'syslog/logger'
+  require 'syslog/logger'
   config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new(ENV['app_name'] || 'rest-whois'))
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?


### PR DESCRIPTION
It is present in Ruby Standard Library since version 2.0.
https://github.com/seattlerb/sysloglogger

Affects production config, needs verification.