### PR TITLE
Remove `SyslogLogger` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem 'rails', '~> 5.2.1'
 gem 'recaptcha', require: 'recaptcha/rails'
 gem 'sass-rails'
 gem 'simpleidn', '0.0.7' # For Punycode
-gem 'SyslogLogger', '2.0', require: 'syslog/logger'
 gem 'uglifier'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    SyslogLogger (2.0)
     actioncable (5.2.1)
       actionpack (= 5.2.1)
       nio4r (~> 2.0)
@@ -187,7 +186,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  SyslogLogger (= 2.0)
   bootsnap
   capybara
   figaro (~> 1.1.0)
@@ -206,4 +204,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.3
+   1.17.1

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,6 +50,7 @@ Rails.application.configure do
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
+  require 'syslog/logger'
   config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new(ENV['app_name'] || 'rest-whois'))
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)


### PR DESCRIPTION
It is present in Ruby Standard Library since version 2.0

https://github.com/seattlerb/sysloglogger