### PR TITLE
update rack to 2.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
     puma (3.12.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.1)


### PR DESCRIPTION
Affected by:
https://access.redhat.com/security/cve/cve-2018-16471
https://access.redhat.com/security/cve/cve-2018-16470