### PR TITLE
Update dockerfile to use Ruby 2.5 with Debian Jessie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM internetee/ruby:2.4
+FROM internetee/ruby:2.5
 MAINTAINER maciej.szlosarczyk@internet.ee
 
 RUN mkdir -p /opt/webapps/app/tmp/pids


### PR DESCRIPTION
No tests are needed, dev only.