### PR TITLE
Test disputed, allow reserved state for both active/inactive domain names

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -6,9 +6,11 @@ class Domain
   STATUS_DISCARDED = 'deleteCandidate'.freeze
   STATUS_AT_AUCTION = 'AtAuction'.freeze
   STATUS_PENDING_REGISTRATION = 'PendingRegistration'.freeze
+  STATUS_DISPUTED = 'Disputed'.freeze
 
-  INACTIVE_STATUSES = [STATUS_BLOCKED, STATUS_RESERVED, STATUS_DISCARDED,
+  INACTIVE_STATUSES = [STATUS_BLOCKED, STATUS_DISCARDED,
                        STATUS_AT_AUCTION, STATUS_PENDING_REGISTRATION].freeze
+  
   private_constant :INACTIVE_STATUSES
 
   attr_accessor :name
@@ -20,6 +22,8 @@ class Domain
   attr_accessor :delete
 
   def active?
+    return false if registered.blank?
+
     (statuses & INACTIVE_STATUSES).empty?
   end
 end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -10,7 +10,7 @@ class Domain
 
   INACTIVE_STATUSES = [STATUS_BLOCKED, STATUS_DISCARDED,
                        STATUS_AT_AUCTION, STATUS_PENDING_REGISTRATION].freeze
-  
+
   private_constant :INACTIVE_STATUSES
 
   attr_accessor :name

--- a/test/models/domain_test.rb
+++ b/test/models/domain_test.rb
@@ -11,7 +11,7 @@ class DomainTest < ActiveSupport::TestCase
   end
 
   def test_active
-    domain = Domain.new(statuses: %w[ok])
+    domain = Domain.new(statuses: %w[ok], registered: Time.now)
     assert domain.active?
   end
 
@@ -22,9 +22,14 @@ class DomainTest < ActiveSupport::TestCase
 
   # A domain in `rest-whois` app can  either be registered or reserved, but in general,
   # a reserved domain _can_ be registered
-  def test_inactive_when_reserved
+  def test_inactive_when_reserved_and_unregistered
     domain = Domain.new(statuses: [Domain::STATUS_RESERVED])
     assert_not domain.active?
+  end
+
+  def test_active_when_reserved_and_registered
+    domain = Domain.new(statuses: [Domain::STATUS_RESERVED], registered: Time.now)
+    assert domain.active?
   end
 
   def test_inactive_when_discarded
@@ -35,6 +40,16 @@ class DomainTest < ActiveSupport::TestCase
   def test_inactive_when_at_auction
     domain = Domain.new(statuses: [Domain::STATUS_AT_AUCTION])
     assert_not domain.active?
+  end
+
+  def test_inactive_when_disputed_and_unregistered
+    domain = Domain.new(statuses: [Domain::STATUS_DISPUTED])
+    assert_not domain.active?
+  end
+
+  def test_active_when_disputed_and_registered
+    domain = Domain.new(statuses: [Domain::STATUS_DISPUTED], registered: Time.now)
+    assert domain.active?
   end
 
   def test_inactive_when_pending_registration

--- a/test/system/contact_requests_confirmation_test.rb
+++ b/test/system/contact_requests_confirmation_test.rb
@@ -40,7 +40,7 @@ class ContactRequestsConfirmationTest < ApplicationSystemTestCase
     visit(new_contact_request_path(params: { domain_name: 'privatedomain.test' }))
     text = begin
       'You will receive an one time link to confirm your email, and then send a message to the owner or administrator ' \
-      "of the domain. " \
+      'of the domain. ' \
       'The link expires in 24 hours.'
     end
 
@@ -68,7 +68,7 @@ class ContactRequestsConfirmationTest < ApplicationSystemTestCase
 
   def test_ru_locale_in_confirmation_form
     visit(new_contact_request_path(params: { domain_name: 'privatedomain.test', locale: 'ru' }))
-    assert_text t('contact_requests.new.help', locale: :ru)
+    assert_text I18n.t('contact_requests.new.help', locale: :ru)
     # TODO: Fix the link when correct
     assert(has_link?(href: 'https://www.internet.ee/domains/eif-s-data-protection-policy'))
   end

--- a/test/system/whois_records/html_test.rb
+++ b/test/system/whois_records/html_test.rb
@@ -21,7 +21,9 @@ class PrivatePersonWhoisRecordHTMLTest < ApplicationSystemTestCase
 
   def test_invalid_domain
     visit('/v1/1.test')
-    assert_text('Domain name policy error: 1.test')
+    assert_text 'Policy error: 1.test. Please study'
+    assert_text 'Requirements for the registration of a Domain Name'
+    assert_text 'https://www.internet.ee/domains/ee-domain-regulation#registration-of-domain-names'
   end
 
   def test_contact_form_link_is_visible_when_captcha_is_solved
@@ -31,7 +33,7 @@ class PrivatePersonWhoisRecordHTMLTest < ApplicationSystemTestCase
   end
 
   def test_contact_form_link_is_visible_when_captcha_is_unsolved
-    visit("v1/privatedomain.test")
+    visit('v1/privatedomain.test')
     refute(has_link?('Contact owner'))
   end
 


### PR DESCRIPTION
Closes #29 

Fixed behaviour for WhoisRecord with reserved state, domain can be active/inactive with reserved status. As disputed status works the same way, it works out of the box in a way described in [registry#269](https://github.com/internetee/registry/issues/269)