### PR TITLE
Fix registration deadline format

### DIFF
--- a/app/models/whois_record.rb
+++ b/app/models/whois_record.rb
@@ -48,7 +48,7 @@ class WhoisRecord < ApplicationRecord
                expire: json['expire'],
                outzone: json['outzone'],
                delete: json['delete'],
-               registration_deadline: json['registration_deadline'])
+               registration_deadline: json['registration_deadline'].try(:to_s, :iso8601))
   end
   # rubocop:enable Metrics/AbcSize
 


### PR DESCRIPTION
sviiter added the registration deadline to internet.ee as well, but said that restwhois returns registration deadline in different format than other dates

"registration_deadline": "2020-06-02 23:59:59 +0300"

while others are:

"changed": "2018-04-10T11:11:15+03:00",
"nameservers_changed": "2017-10-01T23:42:13+03:00",
"registrar_changed": "2020-05-22T13:52:16+03:00",

For this reason Firefox returns invalid date (Chrome parses the date correctly).