### PR TITLE
Mark confirmation link as used after mail has been delivered

### DIFF
--- a/app/controllers/contact_requests_controller.rb
+++ b/app/controllers/contact_requests_controller.rb
@@ -39,7 +39,7 @@ class ContactRequestsController < ApplicationController
   end
 
   def show
-    if @contact_request.confirm_email
+    if @contact_request.confirmable?
       redirect_to edit_contact_request_url
     else
       redirect_to root_url, alert: t('contact_requests.already_used')
@@ -51,12 +51,14 @@ class ContactRequestsController < ApplicationController
   def update
     email_body = params[:email_body]
     recipients = params[:recipients]
+    @contact_request.confirm_email
 
     if @contact_request.send_contact_email(body: email_body, recipients: recipients)
       logger.warn(
         "Email sent to #{@contact_request.whois_record.name} contacts " \
         "from #{@contact_request.email} (IP: #{request.ip})"
       )
+
       render :request_completed
     else
       redirect_to(:root, alert: t('contact_requests.something_went_wrong'))

--- a/app/models/contact_request.rb
+++ b/app/models/contact_request.rb
@@ -64,6 +64,9 @@ class ContactRequest < ApplicationRecord
     status == STATUS_SENT || !still_valid? || !whois_record_exists?
   end
 
+  def confirmable?
+    status == STATUS_NEW && still_valid? && whois_record_exists?
+  end
   private
 
   def extract_emails_for_recipients(recipients)
@@ -81,10 +84,6 @@ class ContactRequest < ApplicationRecord
 
   def sendable?
     status == STATUS_CONFIRMED && still_valid? && whois_record_exists?
-  end
-
-  def confirmable?
-    status == STATUS_NEW && still_valid? && whois_record_exists?
   end
 
   def still_valid?

--- a/test/integration/contact_requests_test.rb
+++ b/test/integration/contact_requests_test.rb
@@ -25,11 +25,11 @@ class ContactRequestsIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def test_opening_link_twice_redirects_you_to_root_with_notice_that_this_link_has_been_used
+  def test_opening_link_twice_does_not_invalidate_link_if_not_used
     visit(contact_request_path(@valid_contact_request.secret))
     visit(contact_request_path(@valid_contact_request.secret))
 
-    assert(page.has_css?('div#flash-alert', text: 'This one-time link has been already used.'))
+    assert_text('Message is limited to 2000 characters')
   end
 
   def test_request_fails_when_whois_record_was_deleted


### PR DESCRIPTION
Closes #200 

Contact link is now marked as used right after it has been used to send actual email.