### PR TITLE
Add special phone disclosure handling for organizational registrants

### DIFF
--- a/app/presenters/registrant_presenter.rb
+++ b/app/presenters/registrant_presenter.rb
@@ -27,7 +27,7 @@ class RegistrantPresenter < ContactPresenter
   end
 
   def disclose_registrant_org_phone
-    if contact.attribute_disclosed?('phone')
+    if contact.attribute_disclosed?('phone') && captcha_solved? || whitelisted_user? || registrant_publishable?
       contact.send('phone')
     else
       disclosable_mask

--- a/app/presenters/registrant_presenter.rb
+++ b/app/presenters/registrant_presenter.rb
@@ -27,7 +27,9 @@ class RegistrantPresenter < ContactPresenter
   end
 
   def disclose_registrant_org_phone
-    if contact.attribute_disclosed?('phone') && captcha_solved? || whitelisted_user? || registrant_publishable?
+    phone_disclosed_and_captcha_solved = contact.attribute_disclosed?('phone') && captcha_solved?
+
+    if phone_disclosed_and_captcha_solved || whitelisted_user? || registrant_publishable?
       contact.send('phone')
     else
       disclosable_mask

--- a/app/presenters/registrant_presenter.rb
+++ b/app/presenters/registrant_presenter.rb
@@ -31,6 +31,8 @@ class RegistrantPresenter < ContactPresenter
 
     if phone_disclosed_and_captcha_solved || whitelisted_user? || registrant_publishable?
       contact.send('phone')
+    elsif !contact.attribute_disclosed?('phone')
+      undisclosable_mask
     else
       disclosable_mask
     end

--- a/app/presenters/registrant_presenter.rb
+++ b/app/presenters/registrant_presenter.rb
@@ -9,8 +9,7 @@ class RegistrantPresenter < ContactPresenter
   end
 
   def phone
-    # publishable_attribute('phone')
-    disclose_data_priv_registrant('phone')
+    registrant_is_org? ? disclose_registrant_org_phone : disclose_data_priv_registrant('phone')
   end
 
   def last_update
@@ -22,6 +21,14 @@ class RegistrantPresenter < ContactPresenter
   def disclose_attr(attr)
     if whitelisted_user? || registrant_publishable? || captcha_solved?
       contact.send(attr.to_sym)
+    else
+      disclosable_mask
+    end
+  end
+
+  def disclose_registrant_org_phone
+    if contact.attribute_disclosed?('phone')
+      contact.send('phone')
     else
       disclosable_mask
     end

--- a/test/integration/whois_records/json_test.rb
+++ b/test/integration/whois_records/json_test.rb
@@ -125,7 +125,7 @@ class WhoisRecordJsonTest < ActionDispatch::IntegrationTest
     response_json = JSON.parse(response.body, symbolize_names: true)
 
     assert_equal 'Not Disclosed - Visit www.internet.ee for web-based WHOIS', response_json[:email]
-    assert_equal 'Not Disclosed', response_json[:phone]
+    assert_equal 'Not Disclosed - Visit www.internet.ee for web-based WHOIS', response_json[:phone]
 
     expected_admin_contacts = [
       { name: 'Not Disclosed - Visit www.internet.ee for web-based WHOIS',
@@ -233,7 +233,7 @@ class WhoisRecordJsonTest < ActionDispatch::IntegrationTest
     response_json = JSON.parse(response.body, symbolize_names: true)
 
     assert_equal 'Not Disclosed - Visit www.internet.ee for web-based WHOIS', response_json[:email]
-    assert_equal 'Not Disclosed', response_json[:phone]
+    assert_equal 'Not Disclosed - Visit www.internet.ee for web-based WHOIS', response_json[:phone]
     assert_equal 'Not Disclosed - Visit www.internet.ee for web-based WHOIS',
                  response_json[:registrant_changed]
 


### PR DESCRIPTION
- Add new method `disclose_registrant_org_phone` to handle phone disclosure for org registrants
- Update phone method to use different disclosure logic for org vs private registrants
- Remove outdated comment about publishable_attribute

close #416 