### PR TITLE
Automated pull request merging

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge-patch:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'internetee/registry'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: |
+          gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,8 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": false,
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
       "automergeType": "pr"
     },
     {


### PR DESCRIPTION
This update will merge Pull Requests with patch updates automatically to master branch.
Requirements:

    Pull requests are made by 'dependabot' or 'renovate bot'
    Pull request is 'patch' version either 1.2.3 -> 1.2.4 or 1.2.3.4 -> 1.2.3.5
    All tests are passed
    Pull Request is up to date with master branch

Minor and Major updates(snyk) for security are not included for auto merge.

NB! After merging this update it is required to set for this repo:

    Settings > General > Pull Requests "Allow auto-merge"
    Settings > Branches > Add rule :

    Require status checks to pass before merging
    Require branches to be up to date before merging
    test (ubuntu-22.04, 3.0.3)
