### PR TITLE
Fix bot auto-merge Mattermost notifications

### DIFF
--- a/.github/workflows/notify-mattermost-bot-automerge.yml
+++ b/.github/workflows/notify-mattermost-bot-automerge.yml
@@ -1,7 +1,7 @@
 name: Notify Mattermost on bot auto-merged PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [master]
 


### PR DESCRIPTION
## Summary
- Switch Mattermost notification workflow to `pull_request_target` so merged Dependabot/Renovate PRs trigger notifications and can access required secrets.

## Why
Dependabot PR merges could be auto-merged and labeled but still produce no Mattermost notification.

## Test plan
- Merge a Dependabot PR that gets `auto-merge-enabled` and confirm Mattermost receives a post.